### PR TITLE
Fix minizinc constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ tomatic_problem_params = {
     "maxTorns": 2,
     "nTorns": [3, 3, 3, 3,],
     "indisponibilitats": [
-        [{1}, {1}, {2}, {1}, {1}],
-        [{2}, {2}, {2}, {2}, {2}],
-        [{3}, {3}, {2}, {3}, {3}],
-        [{2}, {3}, {2}, {2}, {1}],
+        {1}, {1}, {2}, {1}, {1},
+        {2}, {2}, {2}, {2}, {2},
+        {3}, {3}, {2}, {3}, {3},
+        {2}, {3}, {2}, {2}, {1},
     ]
 }
 tomatic_problem = TomaticProblem(**tomatic_problem_params)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,12 +20,14 @@ def tomato_cooker(graellador_path, solvers):
 
 @pytest.fixture
 def tomatic_instance():
+    nPersones = 32
+    nDies = 5
     return TomaticProblem(
-        nPersones=32,
+        nPersones=nPersones,
         nLinies=8,
         nSlots=4,
         nNingus=2,
-        nDies=5,
+        nDies=nDies,
         maxTorns=6,
         nTorns=[
             9,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,4 +97,12 @@ def tomatic_instance():
             {4}, {3}, {2}, {1}, {4},
             {2}, {1}, {3}, {4}, {2},
         ],
+        preferencies=[
+            set() for _ in range(nDies * nPersones)
+        ]
     )
+
+@pytest.fixture
+def tomatic_instance_with_preferences(tomatic_instance):
+    tomatic_instance.preferencies[0].add(2)
+    return tomatic_instance

--- a/tests/test_grill.py
+++ b/tests/test_grill.py
@@ -43,14 +43,32 @@ async def test__grid_tomato_cooker__indisponibilities(
     # given a solver
     tomato_cooker,
     # problem instance
+    tomatic_instance,
+):
+    # When we start a new grid execution
+    results = await tomato_cooker.cook(tomatic_instance)
+
+    # TODO: Have fun 🦄🌈
+    for index, in_this_pony in enumerate(tomatic_instance.indisponibilitats):
+        person = index // tomatic_instance.nDies
+        day = index % tomatic_instance.nDies
+        for little_pony in in_this_pony:
+            assert person + 1 not in results.solution.ocupacioSlot[day][little_pony - 1]
+
+
+@pytest.mark.asyncio
+async def test__grid_tomato_cooker__preferences(
+    # given a solver
+    tomato_cooker,
+    # problem instance
     tomatic_instance_with_preferences,
 ):
     # When we start a new grid execution
     results = await tomato_cooker.cook(tomatic_instance_with_preferences)
 
-    # TODO: Have fun 🦄🌈
-    for index, in_this_pony in enumerate(tomatic_instance_with_preferences.indisponibilitats):
+    # TODO: move your body 🕺
+    for index, prefe_dance in enumerate(tomatic_instance_with_preferences.preferencies):
         person = index // tomatic_instance_with_preferences.nDies
         day = index % tomatic_instance_with_preferences.nDies
-        for little_pony in in_this_pony:
-            assert person + 1 not in results.solution.ocupacioSlot[day][little_pony - 1]
+        for step in prefe_dance:
+            assert person + 1 in results.solution.ocupacioSlot[day][step - 1]

--- a/tests/test_grill.py
+++ b/tests/test_grill.py
@@ -36,3 +36,21 @@ async def test__grid_tomato_cooker__cook(
                 <= len(slot)
                 <= tomatic_instance.nLinies
             )
+
+
+@pytest.mark.asyncio
+async def test__grid_tomato_cooker__indisponibilities(
+    # given a solver
+    tomato_cooker,
+    # problem instance
+    tomatic_instance_with_preferences,
+):
+    # When we start a new grid execution
+    results = await tomato_cooker.cook(tomatic_instance_with_preferences)
+
+    # TODO: Have fun 🦄🌈
+    for index, in_this_pony in enumerate(tomatic_instance_with_preferences.indisponibilitats):
+        person = index // tomatic_instance_with_preferences.nDies
+        day = index % tomatic_instance_with_preferences.nDies
+        for little_pony in in_this_pony:
+            assert person + 1 not in results.solution.ocupacioSlot[day][little_pony - 1]

--- a/tomato_cooker/models/tomatic/phone_grill.mzn
+++ b/tomato_cooker/models/tomatic/phone_grill.mzn
@@ -6,10 +6,12 @@ int: nDies;
 int: maxTorns;
 array[1..nPersones] of int: nTorns;
 array[1..nPersones, 1..nDies] of set of 1..nSlots: indisponibilitats;
+array[1..nPersones, 1..nDies] of set of 1..nSlots: preferencies;
 var (nDies*nSlots*(nLinies-nNingus))..(nDies*nSlots*nLinies): totalTorns;
 
 %cada slot té un set de persones que (d'aquesta forma ja assegurem que no es repeteix persona a un slot)
 array[1..nDies, 1..nSlots] of var set of 1..nPersones: ocupacioSlot;
+
 %dual
 array[1..nDies, 1..nPersones] of var set of 1..nSlots: ocupacioPersona;
 %matriu que guarda quan torns fa cada persona per dia
@@ -22,6 +24,8 @@ constraint forall (d in 1..nDies, s in 1..nSlots, p in 1..nPersones) (((card(ocu
 
 %comprovar que no toca quan no es pot
 constraint forall (d in 1..nDies, p in 1..nPersones) (ocupacioPersona[d,p] intersect indisponibilitats[p,d] = {});
+%comprovar que toca quan es vol
+constraint forall (d in 1..nDies, p in 1..nPersones) (ocupacioPersona[d,p] intersect preferencies[p,d] = preferencies[p,d]);
 % "emplenar" tornsPerDiaPersonaIT
 constraint forall (d in 1..nDies, p in 1..nPersones) (tornsPerDiaPersona[d,p] = card(ocupacioPersona[d,p]));
 %Alternativament Comprovar que no es fan el màxim de torns (2) en un dia

--- a/tomato_cooker/models/tomatic/phone_grill.mzn
+++ b/tomato_cooker/models/tomatic/phone_grill.mzn
@@ -18,46 +18,46 @@ array[1..nDies ,1..nPersones] of var 0..nSlots: tornsPerDiaPersona;
 array[1..nDies] of var (nSlots*(nLinies-nNingus))..(nSlots*nLinies): tornsPerDia;
 
 %mother of all constraints
-constraint forall (i in 1..nDies, j in 1..nSlots, k in 1..nPersones) (((card(ocupacioSlot[i,j])>=(nLinies-nNingus) /\ (card(ocupacioSlot[i,j])<=(nLinies))) /\ ((k in ocupacioSlot[i,j]) <-> (j in ocupacioPersona[i,k])))); 
+constraint forall (d in 1..nDies, s in 1..nSlots, p in 1..nPersones) (((card(ocupacioSlot[d,s])>=(nLinies-nNingus) /\ (card(ocupacioSlot[d,s])<=(nLinies))) /\ ((p in ocupacioSlot[d,s]) <-> (s in ocupacioPersona[d,p])))); 
 
 %comprovar que no toca quan no es pot
-constraint forall (i in 1..nDies, j in 1..nPersones) (ocupacioPersona[i,j] intersect indisponibilitats[j,i] = {});
-% "emplenar" tornsPerDiaPersonaIT  
-constraint forall (i in 1..nDies, j in 1..nPersones) (tornsPerDiaPersona[i,j] = card(ocupacioPersona[i,j]));
+constraint forall (d in 1..nDies, p in 1..nPersones) (ocupacioPersona[d,p] intersect indisponibilitats[p,d] = {});
+% "emplenar" tornsPerDiaPersonaIT
+constraint forall (d in 1..nDies, p in 1..nPersones) (tornsPerDiaPersona[d,p] = card(ocupacioPersona[d,p]));
 %Alternativament Comprovar que no es fan el màxim de torns (2) en un dia
-constraint forall (i in 1..nDies, j in 1..nPersones) (tornsPerDiaPersona[i,j] <= maxTorns);
+constraint forall (d in 1..nDies, p in 1..nPersones) (tornsPerDiaPersona[d,p] <= maxTorns);
 %comprovar que fa igual o menys torns del que li toca
-constraint forall (i in 1..nPersones) (sum(tornsPerDiaPersona[..,i]) <= nTorns[i]);
+constraint forall (p in 1..nPersones) (sum(tornsPerDiaPersona[..,p]) <= nTorns[p]);
 
-constraint forall(i in 1..nDies) (tornsPerDia[i] = sum(tornsPerDiaPersona[i,..]));
+constraint forall(d in 1..nDies) (tornsPerDia[d] = sum(tornsPerDiaPersona[d,..]));
 
 constraint totalTorns = sum(tornsPerDia);
 
 int: tornsDisponibles = sum(nTorns);
 
 output ["Taula ocupacioSlot\n"];
-output [ show(ocupacioSlot[i,j]) ++ 
-        if j == nSlots then "\n" else " " endif|
-         i in 1..nDies, j in 1..nSlots
+output [ show(ocupacioSlot[d,s]) ++
+        if s == nSlots then "\n" else " " endif|
+         d in 1..nDies, s in 1..nSlots
 ];
 output ["\n\n"];
 output ["Taula ocupacioPersona\n"];
-output [ show(ocupacioPersona[i,j]) ++ 
-        if j == nPersones then "\n" else " " endif|
-         i in 1..nDies, j in 1..nPersones
+output [ show(ocupacioPersona[d,p]) ++
+        if p == nPersones then "\n" else " " endif|
+         d in 1..nDies, p in 1..nPersones
 ];
 
 output ["\n\n"];
 output ["Taula tornsPerDiaPersona\n"];
-output [ show(tornsPerDiaPersona[i,j]) ++ 
-        if j == nPersones then "\n" else " " endif|
-         i in 1..nDies, j in 1..nPersones
+output [ show(tornsPerDiaPersona[d,p]) ++
+        if p == nPersones then "\n" else " " endif|
+         d in 1..nDies, p in 1..nPersones
 ];
 
 output ["\n\n"];
 output ["Taula tornsPerDia\n"];
-output [ show(tornsPerDia[i]) ++  " " |
-         i in 1..nDies
+output [ show(tornsPerDia[d]) ++  " " |
+         d in 1..nDies
 ];
 
 output ["\n\n"];

--- a/tomato_cooker/models/tomatic/phone_grill.mzn
+++ b/tomato_cooker/models/tomatic/phone_grill.mzn
@@ -25,7 +25,7 @@ constraint forall (d in 1..nDies, s in 1..nSlots, p in 1..nPersones) (((card(ocu
 %comprovar que no toca quan no es pot
 constraint forall (d in 1..nDies, p in 1..nPersones) (ocupacioPersona[d,p] intersect indisponibilitats[p,d] = {});
 %comprovar que toca quan es vol
-constraint forall (d in 1..nDies, p in 1..nPersones) (ocupacioPersona[d,p] intersect preferencies[p,d] = preferencies[p,d]);
+constraint forall (d in 1..nDies, p in 1..nPersones) (preferencies[p,d] subset ocupacioPersona[d,p]);
 % "emplenar" tornsPerDiaPersonaIT
 constraint forall (d in 1..nDies, p in 1..nPersones) (tornsPerDiaPersona[d,p] = card(ocupacioPersona[d,p]));
 %Alternativament Comprovar que no es fan el màxim de torns (2) en un dia

--- a/tomato_cooker/models/tomatic/tomatic.py
+++ b/tomato_cooker/models/tomatic/tomatic.py
@@ -16,3 +16,4 @@ class TomaticProblem(GridProblem):
     maxTorns: int
     nTorns: list
     indisponibilitats: list
+    preferencies: list


### PR DESCRIPTION
### Case
The users wanted to fix turns.


### Proposed solution

Added a constraint to fix turns:
```
constraint forall (d in 1..nDies, p in 1..nPersones) (ocupacioPersona[d,p] intersect preferencies[p,d] = preferencies[p,d]);
```
We have also added some tests 🦄 🕺
