### PR TITLE
New packaging workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,40 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+  push:
+    tags:
+      - 'tomato-cooker-[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/__version__.py
+++ b/__version__.py
@@ -1,1 +1,0 @@
-VERSION = "0.0.1-beta.0"

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     long_description_content_type="text/markdown",
     license="GNU Affero General Public License v3 or later (AGPLv3+)",
     packages=find_packages(exclude=["*[tT]est*"]),
-    python_requires=">=3.8.*",
+    python_requires=">=3.8.0",
     zip_safe=True,
     setup_requires=[],
     install_requires=required,

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras = {
 }
 
 setup(
-    name="Tomato Cooker",
+    name="tomato-cooker",
     version=VERSION,
     description="Minizinc problem solver",
     author="Som Energia SCCL",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from setuptools import find_packages, setup
 
-from __version__ import VERSION
+from tomato_cooker.__init__ import VERSION
 
 readme = open("README.md").read()
 


### PR DESCRIPTION
Context: Current tomatic CI is blocked because it depends on this packages which is not listed as tomatic dependency neither exists on pypi.

This PR adds a gha workflow to publish packages and fixes the setup to properly build them.
In order to launch it, you can go to Actions and launch manually the workflow. 
After any successful launch you have to change the version in order to properly work again. (You can not republish a package version that already has been published)

The PR also changes these in the build system:

- Changing the package name, all underline without spaces.
- Taking the version from  the package `__init__` instead of `__version __` file at root. Reason: having a single source of truth that can be used from both the code when installed and setup.py before installing.
- Fixed python_requires which contained an unsupported asterisk

You can try to build the package with: `pip install build; python -m build`. We need the merge in order to upload the package using Github actions.

Please, as authors, review at least those arbitrary decissions made by me:

- The package name
- The chosen first version